### PR TITLE
Implementation of OpenRaster layered image file.

### DIFF
--- a/src/heroesgrave/spade/core/CorePlugin.java
+++ b/src/heroesgrave/spade/core/CorePlugin.java
@@ -40,8 +40,10 @@ import heroesgrave.spade.core.changes.SepiaChange;
 import heroesgrave.spade.core.changes.TrueGreyscaleChange;
 import heroesgrave.spade.core.effects.GreyscaleEffect;
 import heroesgrave.spade.core.exporters.ExporterJPEG;
+import heroesgrave.spade.core.exporters.ExporterORA;
 import heroesgrave.spade.core.exporters.ExporterSPD;
 import heroesgrave.spade.core.exporters.ExporterTGA;
+import heroesgrave.spade.core.importers.ImporterORA;
 import heroesgrave.spade.core.importers.ImporterSPD;
 import heroesgrave.spade.core.ops.ResizeCanvasOp;
 import heroesgrave.spade.core.ops.ResizeImageOp;
@@ -117,7 +119,9 @@ public class CorePlugin extends Plugin
 		registrar.registerExporter(new ExporterJPEG());
 		registrar.registerExporter(new ExporterTGA());
 		registrar.registerExporter(new ExporterSPD());
+		registrar.registerExporter(new ExporterORA());
 		
 		registrar.registerImporter(new ImporterSPD());
+		registrar.registerImporter(new ImporterORA());
 	}
 }

--- a/src/heroesgrave/spade/core/exporters/ExporterORA.java
+++ b/src/heroesgrave/spade/core/exporters/ExporterORA.java
@@ -1,0 +1,162 @@
+package heroesgrave.spade.core.exporters;
+
+import java.awt.Graphics2D;
+import java.awt.Image;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.util.List;
+import java.util.zip.Deflater;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import javax.imageio.ImageIO;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.TransformerFactoryConfigurationError;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+
+import org.w3c.dom.Element;
+
+import heroesgrave.spade.image.Document;
+import heroesgrave.spade.image.Layer;
+import heroesgrave.spade.io.ImageExporter;
+
+public class ExporterORA extends ImageExporter
+{
+	private ZipOutputStream zipOut;
+	
+	@Override
+	public String getFileExtension()
+	{
+		return "ora";
+	}
+
+	@Override
+	public void save(Document document, File destination) throws IOException
+	{
+		zipOut = new ZipOutputStream(new FileOutputStream(destination));
+		
+		String mimetype = "image/openraster";
+		
+		//Must write mimetype string with STORED level compression!
+		zipOut.setLevel(ZipOutputStream.STORED);
+        //zipOut.setMethod(ZipOutputStream.STORED);
+		zipOut.putNextEntry(new ZipEntry("mimetype"));
+		zipOut.write(mimetype.getBytes());
+		zipOut.closeEntry();
+		
+		//Compress the rest of the entries
+		zipOut.setLevel(Deflater.DEFAULT_COMPRESSION);
+		//zipOut.setMethod(ZipOutputStream.DEFLATED);
+		zipOut.putNextEntry(new ZipEntry("data/"));
+		zipOut.closeEntry();
+		zipOut.putNextEntry(new ZipEntry("Thumbnails/"));
+		zipOut.closeEntry();
+		
+		//Write all layers to the data/ folder.
+		for (Layer l : document.getFlatMap())
+		{
+			writeLayer(l);
+		}
+		
+		//Write the "merged image" (Just a composite of all the layers.)
+		zipOut.putNextEntry(new ZipEntry("mergedimage.png"));
+		writePNG(document.getRenderedImage());
+		zipOut.closeEntry();
+		
+		//Write the thumbnail (It's mandatory for some reason.)
+		zipOut.putNextEntry(new ZipEntry("Thumbnails/thumbnail.png"));
+		writePNG(resize(document.getRenderedImage(), 256, 256));
+		zipOut.closeEntry();
+		
+		//Write the XML descriptor. This could be refactored into multiple files.
+		try
+		{
+			DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+			DocumentBuilder xmlBuilder = dbf.newDocumentBuilder();
+			org.w3c.dom.Document dom = xmlBuilder.newDocument();
+			
+			Element root = dom.createElement("image");
+			root.setAttribute("version", "0.0.3");
+			root.setAttribute("w", Integer.toString(document.getWidth()));
+			root.setAttribute("h", Integer.toString(document.getHeight()));
+			
+			Element baseStack = dom.createElement("stack");
+			
+			List<Layer> flatMap = document.getFlatMap();
+			for (int i = flatMap.size()-1; i >= 0; i--)
+			{
+				Layer l = flatMap.get(i);
+				Element newLayer = dom.createElement("layer");
+				newLayer.setAttribute("name", l.getMetadata().get("name"));
+				newLayer.setAttribute("src", "data/layer" + l.getLevel() + ".png");
+				baseStack.appendChild(newLayer);
+			}
+			root.appendChild(baseStack);
+			dom.appendChild(root);
+			
+			//Write it to the zip
+			Transformer tr = TransformerFactory.newInstance().newTransformer();
+            tr.setOutputProperty(OutputKeys.INDENT, "yes");
+            tr.setOutputProperty(OutputKeys.METHOD, "xml");
+            tr.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
+            //tr.setOutputProperty(OutputKeys.DOCTYPE_SYSTEM, "roles.dtd");
+            tr.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
+            
+            ByteArrayOutputStream memStream = new ByteArrayOutputStream();
+            tr.transform(new DOMSource(dom), new StreamResult(memStream));
+			
+            zipOut.putNextEntry(new ZipEntry("stack.xml"));
+            zipOut.write(memStream.toByteArray());
+            zipOut.closeEntry();
+		} catch (ParserConfigurationException | TransformerFactoryConfigurationError | TransformerException e)
+		{
+			e.printStackTrace();
+		}
+		
+		//Finalize the zip file.
+		zipOut.flush();
+		zipOut.close();
+	}
+	
+	private void writeLayer(Layer l) throws IOException
+	{
+		zipOut.putNextEntry(new ZipEntry("data/layer" + l.getLevel() + ".png"));
+		writePNG(l.getBufferedImage());
+		zipOut.closeEntry();
+	}
+	
+	private void writePNG(BufferedImage image) throws IOException
+	{
+		ByteArrayOutputStream memStream = new ByteArrayOutputStream();
+		ImageIO.write(image, "png", memStream);
+		zipOut.write(memStream.toByteArray());
+	}
+	
+	private static BufferedImage resize(BufferedImage img, int newW, int newH) { 
+	    Image tmp = img.getScaledInstance(newW, newH, Image.SCALE_SMOOTH);
+	    BufferedImage dimg = new BufferedImage(newW, newH, BufferedImage.TYPE_INT_ARGB);
+
+	    Graphics2D g2d = dimg.createGraphics();
+	    g2d.drawImage(tmp, 0, 0, null);
+	    g2d.dispose();
+
+	    return dimg;
+	}  
+
+	@Override
+	public String getDescription()
+	{
+		return "ORA - Open Raster layered image";
+	}
+
+}

--- a/src/heroesgrave/spade/core/importers/ImporterORA.java
+++ b/src/heroesgrave/spade/core/importers/ImporterORA.java
@@ -1,0 +1,89 @@
+package heroesgrave.spade.core.importers;
+
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.zip.ZipFile;
+
+import javax.imageio.ImageIO;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+
+import org.w3c.dom.Element;
+import org.w3c.dom.NamedNodeMap;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+import org.w3c.dom.Node;
+
+import heroesgrave.spade.image.Document;
+import heroesgrave.spade.image.Layer;
+import heroesgrave.spade.image.RawImage;
+import heroesgrave.spade.io.ImageImporter;
+import heroesgrave.utils.misc.Metadata;
+
+public class ImporterORA extends ImageImporter
+{
+	@Override
+	public boolean load(File file, Document doc) throws IOException
+	{
+		//Reading is sipmle; Just load each layer png from the directory and set name from the XML.
+		ZipFile zip = new ZipFile(file);
+		try
+		{
+			DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+			DocumentBuilder db = dbf.newDocumentBuilder();
+			org.w3c.dom.Document xml = db.parse(zip.getInputStream(zip.getEntry("stack.xml")));
+			
+			Element imageNode = (Element)xml.getElementsByTagName("image").item(0);
+			doc.setDimensions(Integer.parseInt(imageNode.getAttribute("w")), Integer.parseInt(imageNode.getAttribute("h")));
+			
+			NodeList layers = xml.getElementsByTagName("layer"); //Hope it's in order, eh?
+			List<Layer> layerList = new ArrayList<>();
+			for (int i = layers.getLength()-1; i >= 0; i--) //Do it in reverse.
+			{
+				Element l = (Element)layers.item(i);
+				//Create new layer
+				Metadata info = new Metadata();
+				if (l.getAttribute("name") != null)
+					info.set("name", l.getAttribute("name"));
+				
+				//System.out.println(l.getAttribute("src"));
+				BufferedImage buffer = ImageIO.read(zip.getInputStream(zip.getEntry(l.getAttribute("src"))));
+				
+				//Ignoring x and y right now
+				RawImage ri = RawImage.fromBufferedImage(buffer);
+				Layer newLayer = new Layer(doc, ri, info);
+				if (!layerList.isEmpty()) layerList.get(layerList.size()-1).addLayer(newLayer);
+				layerList.add(newLayer);
+			}
+			
+			doc.setRoot(layerList.get(0));
+			
+		} catch (ParserConfigurationException | SAXException e)
+		{
+			e.printStackTrace();
+			return false;
+		} finally
+		{
+			zip.close();
+		}
+		
+		return true;
+	}
+
+	@Override
+	public String getFileExtension()
+	{
+		return "ora";
+	}
+
+	@Override
+	public String getDescription()
+	{
+		return "ORA - Open Raster layered image";
+	}
+
+}


### PR DESCRIPTION
It seems to be fully compatible with most images out there (except for ones with layer
offsets, but Spade doesn't have virtual area to hold layers off the
clipping screen)

I strongly recommend abolishing the goofy tree-style layers menu in
favor of a more traditional list one. Why does it even exist?
